### PR TITLE
Add some hardcoded name and address info to the output

### DIFF
--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -1,0 +1,156 @@
+centers = {
+    "57 Cleveland Place": {
+        "address": "57 Cleveland Pl, Staten Island, NY 10305",
+        "boro": "Staten Island",
+        "fullname": "Former Saint John Villa HS",
+    },
+    "Bay Ridge 5th Avenue": {
+        "address": "8511 & 8515 5th Ave., Brooklyn, NY 11209",
+        "boro": "Brooklyn",
+    },
+    "Bellevue Hospital Cent...": {
+        "address": "462 1st Ave., New York, NY 10016",
+        "boro": "Manhattan",
+        "fullname": "NYC Health + Hospitals / Bellevue",
+    },
+    "Belvis Diagnostic & Tr...": {
+        "address": "545 E 142nd St., Bronx, NY 10454",
+        "boro": "Bronx",
+        "fullname": "NYC Health + Hospitals/Gotham Health, Belvis",
+    },
+    "Bensonhurst 14th Avenue": {
+        "address": "6315 14th Ave., Brooklyn, NY 11219",
+        "boro": "Brooklyn",
+        "fullname": "NYC Health + Hospitals Bensonhurst 14th Ave",
+    },
+    "Coney Island Hospital ...": {
+        "address": "2601 Ocean Pkwy, Brooklyn, NY 11235",
+        "boro": "Brooklyn",
+        "fullname": "NYC Health + Hospitals/Coney Island",
+    },
+    "CU Homecrest": {
+        "address": "1601 Ave. S, Brooklyn, NY 11229",
+        "boro": "Brooklyn",
+        "fullname": "CLOSED?",
+    },
+    "CU Vanderbilt": {
+        "address": "165 Vanderbilt Ave., Staten Island, NY 10304",
+        "boro": "Staten Island",
+        "fullname": "NYC Health + Hospitals/Gotham Health, Vanderbilt",
+    },
+    "CU Woodside Houses CHC": {
+        "address": "50-53 Newtown Rd., Queens, NY 11377",
+        "boro": "Queens",
+        "fullname": "NYC Health + Hospitals/Gotham Health, Woodside",
+    },
+    "Cumberland Dtc": {
+        "address": "100 N Portland Ave., Brooklyn, NY 11205",
+        "boro": "Brooklyn",
+        "fullname": "NYC Health + Hospitals/Gotham Health, Cumberland",
+    },
+    "Elmhurst Hospital Cent...": {
+        "address": "79-01 Broadway, Queens, NY 11373",
+        "boro": "Queens",
+        "fullname": "Elmhurst Hospital Center",
+    },
+    "EY East New York DTC": {
+        "address": "2094 Pitkin Ave., Brooklyn, NY 11207",
+        "boro": "Brooklyn",
+        "fullname": "NYC Health + Hospitals/Gotham Health, East New York",
+    },
+    "Fort Hamilton": {
+        "address": "4002 Fort Hamilton Pkwy, Brooklyn, NY 11218",
+        "boro": "Brooklyn",
+        "fullname": "NYC Health + Hospitals 4002 Fort Hamilton",
+    },
+    "Gouverneur Healthcare": {
+        "address": "227 Madison St., New York, NY 10002",
+        "boro": "Manhattan",
+        "fullname": "NYC Health + Hospitals/Gotham Health, Gouverneur",
+    },
+    "Greenbelt Recreational...": {
+        "address": "501 Brielle Ave., Staten Island, NY 10314",
+        "boro": "Staten Island",
+        "fullname": "Greenbelt Recreation Center",
+    },
+    "Harlem Hospital Center": {
+        "address": "506 Lenox Ave., New York, NY 10037",
+        "boro": "Manhattan",
+        "fullname": "NYC Health + Hospitals/Harlem",
+    },
+    "Jacobi Medical Center": {
+        "address": "1400 Pelham Pkwy S, Bronx, NY 10461",
+        "boro": "Bronx",
+        "fullname": "NYC Health + Hospitals/Jacobi",
+    },
+    "Kings County Hospital ...": {
+        "address": "451 Clarkson Ave., Brooklyn, NY 11203",
+        "boro": "Brooklyn",
+        "fullname": "NYC Health + Hospitals/Kings County",
+    },
+    "Lincoln Medical Center": {
+        "address": "234 East 149th St., Bronx, New York 10451",
+        "boro": "Bronx",
+        "fullname": "NYC Health + Hospitals/Lincoln",
+    },
+    "Metropolitan Hospital ...": {
+        "address": "1901 First Ave., New York, NY 10029",
+        "boro": "Manhattan",
+        "fullname": "NYC Health + Hospitals/Metropolitan",
+    },
+    "Midwood": {
+        "address": "1223 Coney Island Ave., Brooklyn, NY 11230",
+        "boro": "Brooklyn",
+        "fullname": "Midwood Pre-K",
+    },
+    "Morrisania Diagnostic ...": {
+        "address": "1225 Gerard Avenue, Bronx, New York 10452",
+        "boro": "Bronx",
+        "fullname": "NYC Health + Hospitals/Gotham Health, Morrisania",
+    },
+    "North Central Bronx Ho...": {
+        "address": "3424 Kossuth Ave., Bronx, New York 10467",
+        "boro": "Bronx",
+        "fullname": "NYC Health + Hospitals/North Central Bronx",
+    },
+    "Queens Hospital Center": {
+        "address": "82-68 164th Street, Jamaica, New York 11432",
+        "boro": "Queens",
+        "fullname": "NYC Health + Hospitals/Queens",
+    },
+    "Sorrentino Recreationa...": {
+        "address": "18-48 Cornaga Ave.,, Queens, NY 11691",
+        "boro": "Queens",
+        "fullname": "Sorrentino Rec Center",
+    },
+    "St. George Ferry Termi...": {
+        "address": "Terminal 1 Bay St, Retail Space 103, Staten Island, NY 10301",
+        "boro": "Staten Island",
+        "fullname": "NYC Health + Hospitals/Staten Island Ferry Terminal",
+    },
+    "Starret City": {
+        "address": "1279 Granville Payne (Pennysylvania) Ave., Brooklyn, NY 11239",
+        "boro": "Brooklyn",
+        "fullname": "NYC Health + Hospitals/Starett City",
+    },
+    "Sydenham Health Center": {
+        "address": "264 W 118th St., New York NY 10026",
+        "boro": "Manhattan",
+        "fullname": "NYC Health + Hospitals/Gotham Health, Sydenham",
+    },
+    "Times Square": {
+        "address": "701 7th Ave., New York, NY 10036",
+        "boro": "Manhattan",
+        "fullname": "Times Square Testing Site",
+    },
+    "Tremont Community Heal...": {
+        "address": "1920 Webster Ave., Bronx, NY 10457",
+        "boro": "Bronx",
+        "fullname": "NYC Health + Hospitals/Gotham Health Tremont",
+    },
+    "Woodhull Medical Center": {
+        "address": "760 Broadway, Brooklyn, New York 11206",
+        "boro": "Brooklyn",
+        "fullname": "NYC Health + Hospitals/Woodhull",
+    },
+}


### PR DESCRIPTION
The identifiers used in the PDF are a bit terse, so this change
attempts to fill out some more useful info about each center.

"NYC Health + Hospitals/Gotham Health, Homecrest" is listed as
Permanently Closed on Google Maps.